### PR TITLE
Bump to upstream version v1.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG TAG="v1.5"
+ARG TAG=v1.6.0
 ARG COMMIT="52f0664ffcf3b76344374426030b18158567ed40"
 ARG BCI_IMAGE=registry.suse.com/bci/bci-base
 ARG GO_IMAGE=rancher/hardened-build-base:v1.21.11b3
@@ -17,7 +17,7 @@ RUN set -x && \
 # Build the project
 FROM base-builder as builder
 #RUN apk add --update --virtual build-dependencies build-base linux-headers bash
-ARG TAG
+ARG TAG=v1.6.0
 ARG SRC="github.com/k8snetworkplumbingwg"
 ARG REPO_PATH="${SRC}/network-resources-injector"
 RUN git clone --depth=1 https://github.com/k8snetworkplumbingwg/network-resources-injector

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ ORG ?= rancher
 TAG ?= ${GITHUB_ACTION_TAG}
 
 ifeq ($(TAG),)
-TAG := v1.5$(BUILD_META)
+TAG := v1.6.0$(BUILD_META)
 endif
 
 ifeq (,$(filter %$(BUILD_META),$(TAG)))


### PR DESCRIPTION



<Actions>
    <action id="1eebd83cdf50b6b85f2b9734d8925b1d515c7cf3eb31eadf38a95d63428f28ee">
        <h3>Update upstream version</h3>
        <details id="254db0fb64a77d55007f54b1cfb8c3dc722afb404e3dce28e3b46899bce3aacf">
            <summary>Bump Dockerfile to upstream version v1.6.0</summary>
            <p>changed lines [1 20] of file &#34;/tmp/updatecli/github/rancher/image-build-sriov-network-resources-injector/Dockerfile&#34;</p>
            <details>
                <summary>v1.6.0</summary>
                <pre>&#xA;Release published on the 2024-05-30 16:30:39 +0000 UTC at the url https://github.com/k8snetworkplumbingwg/network-resources-injector/releases/tag/v1.6.0&#xA;&#xA;## What&#39;s Changed&#xD;&#xA;* Add CodeQL workflow for GitHub code scanning by @lgtm-com in https://github.com/k8snetworkplumbingwg/network-resources-injector/pull/128&#xD;&#xA;* Bump golang.org/x/text from 0.3.7 to 0.3.8 by @dependabot in https://github.com/k8snetworkplumbingwg/network-resources-injector/pull/131&#xD;&#xA;* Bump golang.org/x/net from 0.0.0-20220127200216-cd36cc0744dd to 0.7.0 by @dependabot in https://github.com/k8snetworkplumbingwg/network-resources-injector/pull/133&#xD;&#xA;* Bump golang.org/x/crypto from 0.0.0-20220214200702-86341886e292 to 0.1.0 by @dependabot in https://github.com/k8snetworkplumbingwg/network-resources-injector/pull/134&#xD;&#xA;* Bump github.com/emicklei/go-restful from 2.10.0+incompatible to 2.16.0+incompatible by @dependabot in https://github.com/k8snetworkplumbingwg/network-resources-injector/pull/130&#xD;&#xA;* Fix CI cluster deployment by @SchSeba in https://github.com/k8snetworkplumbingwg/network-resources-injector/pull/138&#xD;&#xA;* Enable race detection in unit tests by @AlinaSecret in https://github.com/k8snetworkplumbingwg/network-resources-injector/pull/136&#xD;&#xA;* Support pods without volumes by @zeeke in https://github.com/k8snetworkplumbingwg/network-resources-injector/pull/140&#xD;&#xA;* Bump golang.org/x/net from 0.7.0 to 0.17.0 by @dependabot in https://github.com/k8snetworkplumbingwg/network-resources-injector/pull/142&#xD;&#xA;* Disable HTTP/2 by default by @cgoncalves in https://github.com/k8snetworkplumbingwg/network-resources-injector/pull/143&#xD;&#xA;* Fix HTTP/2 disablement by @cgoncalves in https://github.com/k8snetworkplumbingwg/network-resources-injector/pull/145&#xD;&#xA;* Bump golang 1.21 to k8s 1.28.3 by @cgoncalves in https://github.com/k8snetworkplumbingwg/network-resources-injector/pull/144&#xD;&#xA;* Bump golang.org/x/crypto from 0.14.0 to 0.17.0 by @dependabot in https://github.com/k8snetworkplumbingwg/network-resources-injector/pull/146&#xD;&#xA;* add functional tests using the sriov operator by @SchSeba in https://github.com/k8snetworkplumbingwg/network-resources-injector/pull/149&#xD;&#xA;* use non root user by @SchSeba in https://github.com/k8snetworkplumbingwg/network-resources-injector/pull/150&#xD;&#xA;* bump deps by @SchSeba in https://github.com/k8snetworkplumbingwg/network-resources-injector/pull/153&#xD;&#xA;* Bump google.golang.org/protobuf from 1.30.0 to 1.33.0 by @dependabot in https://github.com/k8snetworkplumbingwg/network-resources-injector/pull/151&#xD;&#xA;* Bump golang.org/x/net from 0.17.0 to 0.23.0 by @dependabot in https://github.com/k8snetworkplumbingwg/network-resources-injector/pull/155&#xD;&#xA;&#xD;&#xA;## New Contributors&#xD;&#xA;* @lgtm-com made their first contribution in https://github.com/k8snetworkplumbingwg/network-resources-injector/pull/128&#xD;&#xA;* @dependabot made their first contribution in https://github.com/k8snetworkplumbingwg/network-resources-injector/pull/131&#xD;&#xA;* @AlinaSecret made their first contribution in https://github.com/k8snetworkplumbingwg/network-resources-injector/pull/136&#xD;&#xA;* @zeeke made their first contribution in https://github.com/k8snetworkplumbingwg/network-resources-injector/pull/140&#xD;&#xA;* @cgoncalves made their first contribution in https://github.com/k8snetworkplumbingwg/network-resources-injector/pull/143&#xD;&#xA;&#xD;&#xA;**Full Changelog**: https://github.com/k8snetworkplumbingwg/network-resources-injector/compare/v1.5...v1.6.0</pre>
            </details>
        </details>
        <details id="beda42571c095172ab63437d050612a571d0d9ddd3ad4f2aecbce907a9b7e3d0">
            <summary>Bump Makefile to upstream version v1.6.0</summary>
            <p>1 file(s) updated with &#34;TAG := v1.6.0$$(BUILD_META)&#34;:&#xA;&#x9;* Makefile&#xA;</p>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

